### PR TITLE
Changed config key named `prefix` with `root` for better compatibility

### DIFF
--- a/src/AzureStorageBlobAdapter.php
+++ b/src/AzureStorageBlobAdapter.php
@@ -22,7 +22,7 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
     {
         $serviceClient = BlobServiceClient::fromConnectionString($config['connection_string']);
         $containerClient = $serviceClient->getContainerClient($config['container']);
-        $adapter = new AzureBlobStorageAdapter($containerClient, $config['root'] ?? '');
+        $adapter = new AzureBlobStorageAdapter($containerClient, $config['prefix'] ?? $config['root'] ?? '');
 
         parent::__construct(
             new Filesystem($adapter, $config),

--- a/src/AzureStorageBlobAdapter.php
+++ b/src/AzureStorageBlobAdapter.php
@@ -16,13 +16,13 @@ use League\Flysystem\Filesystem;
 final class AzureStorageBlobAdapter extends FilesystemAdapter
 {
     /**
-     * @param  array{connection_string: string, container: string, prefix?: string}  $config
+     * @param  array{connection_string: string, container: string, root?: string}  $config
      */
     public function __construct(array $config)
     {
         $serviceClient = BlobServiceClient::fromConnectionString($config['connection_string']);
         $containerClient = $serviceClient->getContainerClient($config['container']);
-        $adapter = new AzureBlobStorageAdapter($containerClient, $config['prefix'] ?? '');
+        $adapter = new AzureBlobStorageAdapter($containerClient, $config['root'] ?? '');
 
         parent::__construct(
             new Filesystem($adapter, $config),

--- a/src/AzureStorageBlobAdapter.php
+++ b/src/AzureStorageBlobAdapter.php
@@ -16,7 +16,7 @@ use League\Flysystem\Filesystem;
 final class AzureStorageBlobAdapter extends FilesystemAdapter
 {
     /**
-     * @param  array{connection_string: string, container: string, root?: string}  $config
+     * @param  array{connection_string: string, container: string, prefix?: string, root?: string}  $config
      */
     public function __construct(array $config)
     {

--- a/src/AzureStorageBlobServiceProvider.php
+++ b/src/AzureStorageBlobServiceProvider.php
@@ -23,6 +23,10 @@ final class AzureStorageBlobServiceProvider extends ServiceProvider
                 throw new \InvalidArgumentException('The [container] must be a string in the disk configuration.');
             }
 
+            if (isset($config['prefix']) && ! is_string($config['prefix'])) {
+                throw new \InvalidArgumentException('The [prefix] must be a string in the disk configuration.');
+            }
+            
             if (isset($config['root']) && ! is_string($config['root'])) {
                 throw new \InvalidArgumentException('The [root] must be a string in the disk configuration.');
             }


### PR DESCRIPTION
Changing `prefix` key with `root` so that the adapter becomes compatible with other Laravel ecosystem packages